### PR TITLE
Fix decoding bug in consumer thread

### DIFF
--- a/main_gui_v2.py
+++ b/main_gui_v2.py
@@ -884,7 +884,15 @@ class ConsumeThread(QtCore.QThread):
             for message in self.consumer:
                 if not self._is_running:
                     break
-                msg = f"Offset: {message.offset}, Key: {message.key}, Value: {message.value.decode('utf-8')}"
+                value = message.value
+                if value is not None:
+                    try:
+                        decoded = value.decode('utf-8', errors='replace')
+                    except Exception:
+                        decoded = str(value)
+                else:
+                    decoded = ""
+                msg = f"Offset: {message.offset}, Key: {message.key}, Value: {decoded}"
                 self.message_signal.emit(msg)
                 logging.debug(f"Message: {message}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- handle None values in `ConsumeThread.run` to avoid crash when messages have no value

## Testing
- `python -m py_compile main_gui_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_683dbfff92348322b6e9099c30fe0d0d